### PR TITLE
Update limpet to use latest version of liquid library so we have access to all the default filters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ authors = ["Steve Hoffman <steveh@goofy.net>"]
 [dependencies]
 rustc-serialize = "0.3.19"
 docopt = "0.6.83"
-liquid = "0.8.4"
+liquid = "0.20.0"
 walkdir = "0.1.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,11 +90,9 @@ fn main() {
     let args:Args = Docopt::new(USAGE).and_then(|d| d.decode()).unwrap_or_else(|e| e.exit());
 
     // Build a data context for the liquid templates
-    // let mut data = Context::new();
     let mut data = liquid::Object::new();
     for (key, value) in env::vars() {
         // println!("key: {} value: {}", &key, &value);
-        // data.set_val(&key, Value::Str(value));
         data.insert(key.into(), liquid::model::Value::scalar(value));
     }
 


### PR DESCRIPTION
Re: our discussion about using limpet with filters for limiting the number of concurrent processes airflow can run, I updated limpet to use the latest version of the rust liquid library, which includes the filters that were missing (specifically minus and at_least, both of which, along with a lot more are now included).